### PR TITLE
Allow channels to be changed dynamically

### DIFF
--- a/flutter-engine/src/channel.rs
+++ b/flutter-engine/src/channel.rs
@@ -35,14 +35,14 @@ mod registry;
 mod standard_method_channel;
 
 trait ChannelImpl {
-    fn name(&self) -> &'static str;
+    fn name(&self) -> &str;
     fn init_data(&self) -> Option<Arc<InitData>>;
     fn init(&mut self, runtime_data: Weak<InitData>, plugin_name: &'static str);
     fn plugin_name(&self) -> &'static str;
 }
 
 pub trait Channel {
-    fn name(&self) -> &'static str;
+    fn name(&self) -> &str;
     fn init_data(&self) -> Option<Arc<InitData>>;
     fn init(&mut self, runtime_data: Weak<InitData>, plugin_name: &'static str);
     fn plugin_name(&self) -> &'static str;
@@ -93,7 +93,7 @@ pub trait MethodChannel: Channel {
             if let Some(init_data) = self.init_data() {
                 let runtime_data = (*init_data.runtime_data).clone();
                 let call = self.codec().decode_method_call(msg.message).unwrap();
-                let channel = self.name();
+                let channel = self.name().to_owned();
                 trace!(
                     "on channel {}, got method call {} with args {:?}",
                     channel,
@@ -176,7 +176,7 @@ pub trait MessageChannel: Channel {
             if let Some(init_data) = self.init_data() {
                 let runtime_data = (*init_data.runtime_data).clone();
                 let message = self.codec().decode_message(msg.message).unwrap();
-                let channel = self.name();
+                let channel = self.name().to_owned();
                 trace!("on channel {}, got message {:?}", channel, message);
                 let plugin_name = self.plugin_name();
                 let mut response_handle = msg.response_handle.take();

--- a/flutter-engine/src/channel/basic_message_channel.rs
+++ b/flutter-engine/src/channel/basic_message_channel.rs
@@ -9,7 +9,7 @@ use crate::{
 use log::error;
 
 pub struct BasicMessageChannel {
-    name: &'static str,
+    name: String,
     init_data: Weak<InitData>,
     message_handler: Weak<RwLock<dyn MessageHandler + Send + Sync>>,
     plugin_name: Option<&'static str>,
@@ -17,13 +17,13 @@ pub struct BasicMessageChannel {
 }
 
 impl BasicMessageChannel {
-    pub fn new(
-        name: &'static str,
+    pub fn new<N: AsRef<str>>(
+        name: N,
         message_handler: Weak<RwLock<dyn MessageHandler + Send + Sync>>,
         codec: &'static dyn MessageCodec,
     ) -> Self {
         Self {
-            name,
+            name: name.as_ref().to_owned(),
             init_data: Weak::new(),
             message_handler,
             plugin_name: None,
@@ -37,8 +37,8 @@ impl BasicMessageChannel {
 }
 
 impl ChannelImpl for BasicMessageChannel {
-    fn name(&self) -> &'static str {
-        &self.name
+    fn name(&self) -> &str {
+        self.name.as_ref()
     }
 
     fn init_data(&self) -> Option<Arc<InitData>> {

--- a/flutter-engine/src/channel/event_channel.rs
+++ b/flutter-engine/src/channel/event_channel.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 pub struct EventChannel {
-    name: &'static str,
+    name: String,
     init_data: Weak<InitData>,
     method_handler: Arc<RwLock<dyn MethodCallHandler + Send + Sync>>,
     plugin_name: Option<&'static str>,
@@ -21,9 +21,12 @@ struct EventChannelMethodCallHandler {
 }
 
 impl EventChannel {
-    pub fn new(name: &'static str, handler: Weak<RwLock<dyn EventHandler + Send + Sync>>) -> Self {
+    pub fn new<N: AsRef<str>>(
+        name: N,
+        handler: Weak<RwLock<dyn EventHandler + Send + Sync>>,
+    ) -> Self {
         Self {
-            name,
+            name: name.as_ref().to_owned(),
             init_data: Weak::new(),
             method_handler: Arc::new(RwLock::new(EventChannelMethodCallHandler::new(handler))),
             plugin_name: None,
@@ -32,8 +35,8 @@ impl EventChannel {
 }
 
 impl ChannelImpl for EventChannel {
-    fn name(&self) -> &'static str {
-        &self.name
+    fn name(&self) -> &str {
+        self.name.as_str()
     }
 
     fn init_data(&self) -> Option<Arc<InitData>> {

--- a/flutter-engine/src/channel/json_method_channel.rs
+++ b/flutter-engine/src/channel/json_method_channel.rs
@@ -9,19 +9,19 @@ use crate::{
 };
 
 pub struct JsonMethodChannel {
-    name: &'static str,
+    name: String,
     init_data: Weak<InitData>,
     method_handler: Weak<RwLock<dyn MethodCallHandler + Send + Sync>>,
     plugin_name: Option<&'static str>,
 }
 
 impl JsonMethodChannel {
-    pub fn new(
-        name: &'static str,
+    pub fn new<N: AsRef<str>>(
+        name: N,
         method_handler: Weak<RwLock<dyn MethodCallHandler + Send + Sync>>,
     ) -> Self {
         Self {
-            name,
+            name: name.as_ref().to_owned(),
             init_data: Weak::new(),
             method_handler,
             plugin_name: None,
@@ -37,8 +37,8 @@ impl JsonMethodChannel {
 }
 
 impl ChannelImpl for JsonMethodChannel {
-    fn name(&self) -> &'static str {
-        &self.name
+    fn name(&self) -> &str {
+        self.name.as_str()
     }
 
     fn init_data(&self) -> Option<Arc<InitData>> {

--- a/flutter-engine/src/channel/macros.rs
+++ b/flutter-engine/src/channel/macros.rs
@@ -1,7 +1,7 @@
 macro_rules! method_channel {
     ($channel:ty) => {
         impl $crate::channel::Channel for $channel {
-            fn name(&self) -> &'static str {
+            fn name(&self) -> &str {
                 ChannelImpl::name(self)
             }
 
@@ -35,7 +35,7 @@ macro_rules! method_channel {
 macro_rules! message_channel {
     ($channel:ty) => {
         impl $crate::channel::Channel for $channel {
-            fn name(&self) -> &'static str {
+            fn name(&self) -> &str {
                 ChannelImpl::name(self)
             }
 

--- a/flutter-engine/src/channel/registry.rs
+++ b/flutter-engine/src/channel/registry.rs
@@ -29,6 +29,10 @@ impl ChannelRegistry {
         }
     }
 
+    pub fn remove_channel(&mut self, channel_name: &str) -> Option<Arc<dyn Channel>> {
+        self.channels.remove(channel_name)
+    }
+
     pub fn with_channel_registrar<F>(&mut self, plugin_name: &'static str, f: F)
     where
         F: FnOnce(&mut ChannelRegistrar),

--- a/flutter-engine/src/channel/registry.rs
+++ b/flutter-engine/src/channel/registry.rs
@@ -41,7 +41,7 @@ impl ChannelRegistry {
         f(&mut registrar);
     }
 
-    pub fn with_channel<F>(&self, channel_name: &'static str, mut f: F)
+    pub fn with_channel<F>(&self, channel_name: &str, mut f: F)
     where
         F: FnMut(&dyn Channel),
     {

--- a/flutter-engine/src/channel/standard_method_channel.rs
+++ b/flutter-engine/src/channel/standard_method_channel.rs
@@ -9,19 +9,19 @@ use crate::{
 };
 
 pub struct StandardMethodChannel {
-    name: &'static str,
+    name: String,
     init_data: Weak<InitData>,
     method_handler: Weak<RwLock<dyn MethodCallHandler + Send + Sync>>,
     plugin_name: Option<&'static str>,
 }
 
 impl StandardMethodChannel {
-    pub fn new(
-        name: &'static str,
+    pub fn new<N: AsRef<str>>(
+        name: N,
         method_handler: Weak<RwLock<dyn MethodCallHandler + Send + Sync>>,
     ) -> Self {
         Self {
-            name,
+            name: name.as_ref().to_owned(),
             init_data: Weak::new(),
             method_handler,
             plugin_name: None,
@@ -37,8 +37,8 @@ impl StandardMethodChannel {
 }
 
 impl ChannelImpl for StandardMethodChannel {
-    fn name(&self) -> &'static str {
-        &self.name
+    fn name(&self) -> &str {
+        self.name.as_str()
     }
 
     fn init_data(&self) -> Option<Arc<InitData>> {

--- a/flutter-engine/src/desktop_window_state.rs
+++ b/flutter-engine/src/desktop_window_state.rs
@@ -37,7 +37,7 @@ const FUNCTION_MODIFIER_KEY: glfw::Modifiers = glfw::Modifiers::Control;
 const FUNCTION_MODIFIER_KEY: glfw::Modifiers = glfw::Modifiers::Super;
 
 pub(crate) type MainThreadWindowFn = Box<dyn FnMut(&mut glfw::Window) + Send>;
-pub(crate) type MainThreadChannelFn = (&'static str, Box<dyn FnMut(&dyn Channel) + Send>);
+pub(crate) type MainThreadChannelFn = (String, Box<dyn FnMut(&dyn Channel) + Send>);
 pub(crate) type MainThreadPlatformMsg = (String, Vec<u8>);
 pub(crate) type MainThreadRenderThreadFn = Box<dyn FnMut(&mut glfw::Window) + Send>;
 pub(crate) type MainTheadWindowStateFn = Box<dyn FnMut(&mut DesktopWindowState) + Send>;
@@ -105,7 +105,7 @@ impl RuntimeData {
 
     pub fn with_channel<F>(
         &self,
-        channel_name: &'static str,
+        channel_name: String,
         mut f: F,
     ) -> Result<(), crate::error::RuntimeMessageError>
     where
@@ -547,7 +547,7 @@ impl DesktopWindowState {
                 MainThreadCallback::ChannelFn((name, mut f)) => {
                     self.plugin_registrar
                         .channel_registry
-                        .with_channel(name, |channel| {
+                        .with_channel(&name, |channel| {
                             f(channel);
                         });
                 }


### PR DESCRIPTION
This PR allows channels with non-static names. Some plugins open channels with names determined at runtime, so this change allows these plugins to be implemented in Rust as well. These channels can also be removed again as to not keep too many channels open at runtime.