### PR TITLE
Add support for external textures

### DIFF
--- a/flutter-engine/src/desktop_window_state.rs
+++ b/flutter-engine/src/desktop_window_state.rs
@@ -606,15 +606,15 @@ impl DesktopWindowState {
         }
     }
 
-    pub fn shutdown(self) {
+    pub fn shutdown(self) -> Arc<FlutterEngine> {
         let mut guard = ENGINES.lock().unwrap();
         unsafe {
             let window: &glfw::Window = &*self.window_ref;
             guard.remove(&WindowSafe(window.window_ptr()));
         }
 
-        self.init_data.engine.shutdown();
         self.runtime.shutdown_now().wait().unwrap();
+        Arc::clone(&self.init_data.engine)
     }
 }
 

--- a/flutter-engine/src/desktop_window_state.rs
+++ b/flutter-engine/src/desktop_window_state.rs
@@ -17,6 +17,7 @@ use lazy_static::lazy_static;
 
 use crate::{
     channel::Channel,
+    event_loop::wake_platform_thread,
     ffi::{
         FlutterEngine, FlutterPointerMouseButtons, FlutterPointerPhase, FlutterPointerSignalKind,
     },
@@ -89,6 +90,7 @@ impl RuntimeData {
                 let result = f(window);
                 tx.send(result).unwrap();
             })))?;
+        wake_platform_thread();
         Ok(rx.recv()?)
     }
 
@@ -100,6 +102,7 @@ impl RuntimeData {
             .send(MainThreadCallback::WindowFn(Box::new(move |window| {
                 f(window);
             })))?;
+        wake_platform_thread();
         Ok(())
     }
 
@@ -118,6 +121,7 @@ impl RuntimeData {
                     f(channel);
                 }),
             )))?;
+        wake_platform_thread();
         Ok(())
     }
 
@@ -128,6 +132,7 @@ impl RuntimeData {
     ) -> Result<(), crate::error::RuntimeMessageError> {
         self.main_thread_sender
             .send(MainThreadCallback::PlatformMessage((channel_name, data)))?;
+        wake_platform_thread();
         Ok(())
     }
 
@@ -144,6 +149,7 @@ impl RuntimeData {
                     f(window);
                 },
             )))?;
+        wake_platform_thread();
         Ok(())
     }
 

--- a/flutter-engine/src/event_loop.rs
+++ b/flutter-engine/src/event_loop.rs
@@ -119,6 +119,12 @@ impl EventLoop {
     }
 }
 
+pub fn wake_platform_thread() {
+    unsafe {
+        glfw::ffi::glfwPostEmptyEvent();
+    }
+}
+
 impl Ord for TaskPriority {
     fn cmp(&self, other: &Self) -> Ordering {
         match self.time.cmp(&other.time) {

--- a/flutter-engine/src/lib.rs
+++ b/flutter-engine/src/lib.rs
@@ -379,7 +379,12 @@ impl FlutterDesktop {
 
     fn shutdown(self) {
         if let DesktopUserData::WindowState(window_state) = self.user_data.into_inner() {
-            window_state.shutdown();
+            // The window state itself must be dropped completely to make sure that all plugins and textures
+            // are cleaned up. Only then may the engine itself be shutdown.
+            let engine = window_state.shutdown();
+            // The window state is consumed by `shutdown`, so by now it has been dropped. We can shut down the
+            // engine itself now.
+            engine.shutdown();
         }
     }
 }

--- a/flutter-engine/src/lib.rs
+++ b/flutter-engine/src/lib.rs
@@ -24,6 +24,7 @@ mod event_loop;
 mod ffi;
 mod flutter_callbacks;
 pub mod plugins;
+pub mod texture_registry;
 mod utils;
 
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
@@ -265,7 +266,9 @@ impl FlutterDesktop {
                     fbo_reset_after_present: false,
                     surface_transformation: None,
                     gl_proc_resolver: Some(flutter_callbacks::gl_proc_resolver),
-                    gl_external_texture_frame_callback: None,
+                    gl_external_texture_frame_callback: Some(
+                        flutter_callbacks::gl_external_texture_frame,
+                    ),
                 },
             },
         };

--- a/flutter-engine/src/texture_registry.rs
+++ b/flutter-engine/src/texture_registry.rs
@@ -1,0 +1,187 @@
+use std::{
+    collections::HashMap,
+    convert::TryInto,
+    sync::{atomic::AtomicI64, Arc, Mutex, Weak},
+};
+
+use flutter_engine_sys::FlutterOpenGLTexture;
+use gl::types::*;
+use log::{debug, trace};
+
+use crate::ffi::{ExternalTexture as FlutterTexture, FlutterEngine};
+
+type TextureID = i64;
+
+pub struct TextureRegistry {
+    engine: Arc<FlutterEngine>,
+    textures: TextureStore,
+}
+
+struct TextureStore {
+    /// Stores freshly registered textures without an OpenGL texture attached.
+    initial: HashMap<TextureID, Arc<ExternalTexture>>,
+    /// Stores created textures that may be dropped in other locations.
+    created: HashMap<TextureID, Weak<ExternalTexture>>,
+}
+
+pub struct ExternalTexture {
+    texture: FlutterTexture,
+    texture_data: Mutex<Option<TextureData>>,
+}
+
+struct TextureData {
+    name: GLuint,
+    width: u32,
+    height: u32,
+}
+
+struct TextureUserData {
+    texture_id: TextureID,
+    texture_name: GLuint,
+}
+
+impl TextureRegistry {
+    pub fn new(engine: Arc<FlutterEngine>) -> Self {
+        Self {
+            engine,
+            textures: TextureStore {
+                initial: HashMap::new(),
+                created: HashMap::new(),
+            },
+        }
+    }
+
+    pub fn create_texture(&mut self) -> Arc<ExternalTexture> {
+        static TEXTURE_ID: AtomicI64 = AtomicI64::new(1);
+
+        let texture_id = TEXTURE_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let flutter_texture = self.engine.register_external_texture(texture_id);
+
+        let texture = Arc::new(ExternalTexture {
+            texture: flutter_texture,
+            texture_data: Mutex::new(None),
+        });
+
+        self.textures
+            .initial
+            .insert(texture_id, Arc::clone(&texture));
+
+        texture
+    }
+
+    pub(crate) fn texture_callback(
+        &mut self,
+        texture_id: TextureID,
+        (width, height): (u32, u32),
+        gl_texture: &mut FlutterOpenGLTexture,
+    ) -> bool {
+        if let Some(texture) = self.textures.initial.remove(&texture_id) {
+            // texture is still initial --> create it
+            unsafe {
+                create_gl_texture(texture_id, (width, height), gl_texture);
+            }
+            let mut data = texture.texture_data.lock().unwrap();
+            data.replace(TextureData {
+                name: gl_texture.name,
+                width,
+                height,
+            });
+            self.textures
+                .created
+                .insert(texture_id, Arc::downgrade(&texture));
+            return true;
+        }
+
+        if let Some(texture) = self.textures.created.get(&texture_id) {
+            // texture has been created, this is a notification that a new frame is available
+            if let Some(_texture) = texture.upgrade() {
+                // texture still alive
+                // TODO: notify of new frame
+            } else {
+                // texture was dropped, remove it from here as well
+                self.textures.created.remove(&texture_id);
+            }
+        }
+        false
+    }
+}
+
+impl ExternalTexture {
+    pub fn handle(&self) -> TextureID {
+        self.texture.texture_id
+    }
+
+    pub fn gl_texture(&self) -> Option<GLuint> {
+        let data = self.texture_data.lock().unwrap();
+        data.as_ref().map(|data| data.name)
+    }
+
+    pub fn size(&self) -> Option<(u32, u32)> {
+        let data = self.texture_data.lock().unwrap();
+        data.as_ref().map(|data| (data.width, data.height))
+    }
+
+    pub fn mark_frame_available(&self) {
+        self.texture.mark_frame_available();
+    }
+}
+
+unsafe fn create_gl_texture(
+    texture_id: TextureID,
+    (width, height): (u32, u32),
+    gl_texture: &mut flutter_engine_sys::FlutterOpenGLTexture,
+) {
+    debug!(
+        "creating external texture with id {}, size {}x{}",
+        texture_id, width, height,
+    );
+    gl_texture.target = gl::TEXTURE_2D;
+    gl_texture.format = gl::RGBA8;
+    gl::GenTextures(1, &mut gl_texture.name as *mut _);
+    gl::BindTexture(gl::TEXTURE_2D, gl_texture.name);
+    gl::PixelStorei(gl::UNPACK_ALIGNMENT, 1);
+    gl::TexParameteri(
+        gl::TEXTURE_2D,
+        gl::TEXTURE_MIN_FILTER,
+        gl::LINEAR.try_into().unwrap(),
+    );
+    gl::TexParameteri(
+        gl::TEXTURE_2D,
+        gl::TEXTURE_MAG_FILTER,
+        gl::LINEAR.try_into().unwrap(),
+    );
+    // length of data: 4 bytes per pixel (RGBA)
+    let data_length = (width * height * 4) as usize;
+    let data = vec![0_u8; data_length];
+    gl::TexImage2D(
+        gl::TEXTURE_2D,
+        0,                            // mipmap level
+        gl::RGBA.try_into().unwrap(), // internal format of the texture
+        width.try_into().unwrap(),
+        height.try_into().unwrap(),
+        0,                         // border, must be 0
+        gl::RGBA,                  // format of the pixel data
+        gl::UNSIGNED_BYTE,         // data type of the pixel data
+        data.as_ptr() as *const _, // pixel data
+    );
+    let user_data = Box::new(TextureUserData {
+        texture_id,
+        texture_name: gl_texture.name,
+    });
+    gl_texture.user_data = Box::into_raw(user_data) as *mut _;
+    gl_texture.destruction_callback = Some(texture_destruction_callback);
+    debug!(
+        "created texture {}, gl texture {}",
+        texture_id, gl_texture.name
+    );
+}
+
+unsafe extern "C" fn texture_destruction_callback(user_data: *mut libc::c_void) {
+    trace!("texture_destruction_callback");
+    let user_data = Box::from_raw(user_data as *mut TextureUserData);
+    debug!(
+        "destroying texture {}, gl texture {}",
+        user_data.texture_id, user_data.texture_name
+    );
+    gl::DeleteTextures(1, &user_data.texture_name as *const _);
+}


### PR DESCRIPTION
This PR allows the creation and use of external textures. The embedder can render into these textures with normal OpenGL commands and the flutter engine will pick up on them.